### PR TITLE
Manual callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.pyc
 /*.egg
 /*.egg-info
-/.coverage
+/.coverage*
 /.tox
+/.eggs
+/.idea
 /AUTHORS
 /ChangeLog

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
 
-install: pip install tox
+install: pip install tox-travis
 script:
     - tox
 

--- a/callbacks/callbacks.py
+++ b/callbacks/callbacks.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function
 import types
 from collections import defaultdict
 from weakref import WeakKeyDictionary, proxy
-import uuid
 import inspect
 import sys
 
@@ -23,254 +22,173 @@ else:
         return types.MethodType(func, obj, obj.__class__)
 
 
-class AbstractCallbackRegistry(object):
-    '''
-        This decorator enables a function or a class/instance method to register
-    callbacks.  Callbacks can be registered to be run before or after the
-    target function (or after the target function raises an exception).
-    See the docstring for add_*_callback for more information.
-    '''
-    def __init__(self, target, target_is_method=False):
-        self.id = uuid.uuid4()
-
-        self.target = target
-        self.__name__ = target.__name__
-        if hasattr(target, '_argspec'):
-            self._argspec = target._argspec
-        else:
-            self._argspec = inspect.getargspec(target)
-
-        self._target_is_method = target_is_method
+class Event(object):
+    """
+    Holds a set of callbacks registered using `add_callback()` handles
+    executing them when `emit()` is called.
+    """
+    def __init__(self, name, target_name):
+        self.name = name
+        self.target_name = target_name
         self._initialize()
 
-    @property
-    def num_callbacks(self):
-        """
-            Retuns the number of callbacks that have been registered on this
-        function/method.  If called on an instance-method then it will also
-        return the number of class-level callbacks.
-
-        Returns:
-            num_callbacks
-            -or-
-            (num_class_level_callbacks, num_instance_level_callbacks)
-        """
-        num = len(self.callbacks)
-        if isinstance(self.target, self.__class__):
-            return self.target.num_callbacks, num
-        else:
-            return num
-
     def _initialize(self):
-        # this will hold the registries for instance method callbacks
-        self._callback_registries = WeakKeyDictionary()
-
-        # this holds the callback functions and how they should be called
+        # mapping of id to callback info dict
         self.callbacks = defaultdict(dict)
-        self._priorities = defaultdict(lambda: defaultdict(list))
+        # mapping of priority to list of ids
+        self._priorities = defaultdict(list)
 
-    def _iter_callbacks(self, type):
-        '''
+    @staticmethod
+    def _callback_id(target):
+        """
+        Given a listener object, return the key that would be used to identify it
+        for the purposes of event registration.
+        """
+        if isinstance(target, types.MethodType):
+            return id(target.im_self), id(target.im_func)
+        return id(target)
+
+    def _iter_callbacks(self):
+        """
         Iterate over callbacks in order of priority.
-        '''
-        for priority in sorted(self._priorities[type].keys(), reverse=True):
-            for label in self._priorities[type][priority]:
-                info = self.callbacks[label]
-                yield (info['function'], info['extra'])
+        """
+        for priority in sorted(self._priorities.keys(), reverse=True):
+            for id in self._priorities[priority]:
+                info = self.callbacks[id]
+                yield (info['function'], id, info['extra'])
 
-    @property
-    def _callbacks_info(self):
-        extra_labels = set()
-        for info in self.callbacks.values():
-            extra_labels.update(info['extra'].keys())
-        extra_labels = sorted(extra_labels)
-        format_extra = '  '.join(['{%s:<%d}' % (x, len(x))
-                                  for x in extra_labels])
-        format_string = '{label:<38}  {priority:<9}  {order:<6}  {type:<10}  {extra}'
-        lines = []
-        lines.append(
-            format_string.format(label='Label', priority='Priority',
-                                 order='Order', type='Type',
-                                 extra=format_extra.format(
-                                     **{x : x.replace('_', ' ').capitalize()
-                                        for x in extra_labels})))
-
-        for label, info in sorted(self.callbacks.items()):
-            order = self._priorities[info['type']][info['priority']].index(label)
-            extra = info['extra']
-            lines.append(
-                format_string.format(label=label, priority=info['priority'],
-                                     order=order, type=info['type'],
-                                     extra=format_extra.format(
-                                         **{x : extra.get(x, 'N/A')
-                                            for x in extra_labels})).rstrip())
-
-        return '\n'.join(lines)
-
-    def list_callbacks(self):
-        '''
-            List all of the callbacks registered to this function or method.
-        '''
-        print(self._callbacks_info)
-
-    def _add_callback(self, callback, priority, label, type, extra):
+    def _add_callback(self, callback, priority, id, extra):
         try:
             priority = float(priority)
         except:
             raise ValueError('Priority could not be cast into a float.')
 
-        if label is None:
-            label = uuid.uuid4()
+        if id is None:
+            id = self._callback_id(callback)
 
-        if label in self.callbacks.keys():
-            raise RuntimeError('Callback with label="%s" already registered.'
-                               % label)
+        if id in self.callbacks.keys():
+            raise RuntimeError('Callback with id="%s" already registered.'
+                               % id)
 
         entry = {
             'function': callback,
             'priority': priority,
-            'type': type,
             'extra': extra or {}
         }
-        self.callbacks[label] = entry
-        self._priorities[type][priority].append(label)
-        return label
+        self.callbacks[id] = entry
+        self._priorities[priority].append(id)
+        return id
 
-    def remove_callback(self, label):
-        '''
-        Unregisters the callback from the target.
-
-        Inputs:
-            label: The name of the callback.  This was either supplied as a
-                keyword argument to add_callback or was automatically generated
-                and returned from add_callback. If label is not valid a
-                RuntimeError is raised.
-        Returns:
-            None
-        '''
-        if label not in self.callbacks:
-            raise RuntimeError(
-                'No callback with label "%s" attached to function "%s"' %
-                (label, self.target.__name__))
-
-        for priomap in self._priorities.values():
-            for priority in priomap.keys():
-                if label in priomap[priority]:
-                    priomap[priority].remove(label)
-
-        del self.callbacks[label]
-
-    def remove_callbacks(self, labels=None):
-        '''
-        Unregisters callback(s) from the target.
-
-        Inputs:
-            labels: A list of callback labels.  If empty, all callbacks will
-                be removed.
-        Returns:
-            None
-        '''
-        if labels is not None:
-            bad_labels = []
-            for label in labels:
-                try:
-                    self.remove_callback(label)
-                except RuntimeError:
-                    bad_labels.append(label)
-                    continue
-            if bad_labels:
-                raise RuntimeError(
-                    'No callbacks with labels %s attached to function %s' %
-                    (bad_labels, self.target.__name__))
-        else:
-            self._initialize()
-
-
-class SupportsCallbacks(AbstractCallbackRegistry):
-    def _initialize(self):
-        super(SupportsCallbacks, self)._initialize()
-        self._update_docstring(self.target)
-        # alias
-        self.add_callback = self.add_post_callback
-
-    def __get__(self, obj, obj_type=None):
+    def add_callback(self, callback, priority=0, id=None,
+                     takes_target_args=False):
         """
-            To allow each instance of a class to have different callbacks
-        registered we store a callback registry on the instance itself.
-        Keying off of the id of the decorator allows us to have multiple
-        methods support callbacks on the same instance simultaneously.
-        """
-        # method is being called on the class instead of an instance
-        if obj is None:
-            # when target was decorated, it had not been bound yet, but now it
-            # is, so update _target_is_method.
-            self._target_is_method = True
-            return self
-
-        if obj not in self._callback_registries:
-            callback_registry = self.__class__(
-                self, target_is_method=True)
-            self._callback_registries[obj] = proxy(callback_registry)
-        else:
-            callback_registry = self._callback_registries[obj]
-
-        return create_bound_method(callback_registry, obj)
-
-    def __call__(self, *args, **kwargs):
-        print('self %s %s' % (self, self.target))
-        if self._target_is_method:
-            cb_args = args[1:]  # skip over 'self' arg
-        else:
-            cb_args = args
-
-        self._call_pre_callbacks(*cb_args, **kwargs)
-        try:
-            target_result = self.target(*args, **kwargs)
-        except Exception as e:
-            target_result = self._call_exception_callbacks(e, *cb_args, **kwargs)
-        self._call_post_callbacks(target_result, *cb_args, **kwargs)
-        return target_result
-
-    def add_pre_callback(self, callback, priority=0, label=None,
-                         takes_target_args=False):
-        '''
-        Registers the callback to be called before the target.
+        Registers the callback.
 
         Inputs:
             callback: The callback function that will be called before
                 the target function is run.
             priority: Number. Higher priority callbacks are run first,
                 ties are broken by the order in which callbacks were added.
-            label: A name to call this callback, must be unique (and hashable)
+            id: A name to call this callback, must be unique (and hashable)
                 or None, if non-unique a RuntimeError will be raised.
-                If None, a unique label will be automatically generated.
-                NOTE: Callbacks can be removed using their label.
+                If None, a unique id will be automatically generated.
+                NOTE: Callbacks can be removed using their id.
                       (see remove_callback)
             takes_target_args: If True, callback function will be passed the
                 arguments and keyword arguments that are supplied to the
                 target function.
         Returns:
-            label
-        '''
+            id
+        """
         return self._add_callback(
-            callback=callback, priority=priority, label=label, type='pre',
+            callback=callback, priority=priority, id=id,
             extra={'takes_args': takes_target_args})
 
-    def add_post_callback(self, callback, priority=0, label=None,
-                          takes_target_args=False,
-                          takes_target_result=False):
-        '''
-            Registers the callback to be called after the target is called.
+    def remove_callback(self, id):
+        """
+        Unregisters the callback.
+
+        Inputs:
+            id: The name of the callback, the id returned by add_callback,
+                or the callback itself.  This was either supplied as a
+                keyword argument to add_callback or was automatically generated
+                and returned from add_callback. If id is not valid a
+                RuntimeError is raised.
+        Returns:
+            None
+        """
+        if callable(id):
+            # convert the original callable to an id
+            id = self._callback_id(id)
+
+        if id not in self.callbacks:
+            raise RuntimeError(
+                '%s: No callback with id "%s" attached to function "%s"' %
+                (self.name, id, self.target_name))
+
+        for ids in self._priorities.values():
+            if id in ids:
+                ids.remove(id)
+
+        del self.callbacks[id]
+
+    def remove_callbacks(self, ids=None):
+        """
+        Unregisters callback(s) from the target.
+
+        Inputs:
+            ids: A list of callback ids.  If empty, all callbacks will
+                be removed.
+        Returns:
+            None
+        """
+        if ids is not None:
+            bad_ids = []
+            for id in ids:
+                if callable(id):
+                    id = self._callback_id(id)
+                try:
+                    self.remove_callback(id)
+                except RuntimeError:
+                    bad_ids.append(id)
+                    continue
+            if bad_ids:
+                raise RuntimeError(
+                    '%s: No callbacks with ids %s attached to function %s' %
+                    (self.name, bad_ids, self.target_name))
+        else:
+            self._initialize()
+
+    def emit(self, *args, **kwargs):
+        """
+        Call all of the callbacks registered with this event.
+        """
+        results = {}
+        for callback, id, extra in self._iter_callbacks():
+            takes_target_args = extra['takes_args']
+            if takes_target_args:
+                results[id] = callback(*args, **kwargs)
+            else:
+                results[id] = callback()
+        return results
+
+
+class PostReturnEvent(Event):
+
+    def add_callback(self, callback, priority=0, id=None,
+                     takes_target_args=False, takes_target_result=False):
+        """
+        Registers the callback to be called after the target is called.
 
         Inputs:
             callback: The callback function that will be called after
                 the target is called.
             priority: Number. Higher priority callbacks are run first,
                 ties are broken by the order in which callbacks were added.
-            label: A name to call this callback, must be unique (and hashable)
+            id: A name to call this callback, must be unique (and hashable)
                 or None, if non-unique a RuntimeError will be raised.
-                If None, a unique label will be automatically generated.
-                NOTE: Callbacks can be removed using their label.
+                If None, a unique id will be automatically generated.
+                NOTE: Callbacks can be removed using their id.
                       (see remove_callback)
             takes_target_args: If True, callback function will be passed the
                 arguments and keyword arguments that are supplied to the
@@ -279,18 +197,35 @@ class SupportsCallbacks(AbstractCallbackRegistry):
                 its first argument, the value returned from calling the
                 target function.
         Returns:
-            label
-        '''
+            id
+        """
         return self._add_callback(
-            callback=callback, priority=priority, label=label, type='post',
+            callback=callback, priority=priority, id=id,
             extra={'takes_args': takes_target_args,
                    'takes_result': takes_target_result})
 
-    def add_exception_callback(self, callback, priority=0, label=None,
-                               takes_target_args=False,
-                               handles_exception=False):
-        '''
-            Registers the callback to be called after the target raises an
+    def emit(self, target_result, *args, **kwargs):
+        results = {}
+        for callback, id, extra in self._iter_callbacks():
+            takes_target_args = extra['takes_args']
+            takes_target_result = extra['takes_result']
+            if takes_target_args and takes_target_result:
+                results[id] = callback(target_result, *args, **kwargs)
+            elif takes_target_result:
+                results[id] = callback(target_result)
+            elif takes_target_args:
+                results[id] = callback(*args, **kwargs)
+            else:
+                results[id] = callback()
+        return results
+
+
+class ExceptionEvent(Event):
+
+    def add_callback(self, callback, priority=0, id=None,
+                     takes_target_args=False, handles_exception=False):
+        """
+        Registers the callback to be called after the target raises an
         exception.  Exception callbacks are called in priority order and can
         handle the exception if they register with <handles_exception>.
 
@@ -299,10 +234,10 @@ class SupportsCallbacks(AbstractCallbackRegistry):
                 the target function raises an exception.
             priority: Number. Higher priority callbacks are run first,
                 ties are broken by the order in which callbacks were added.
-            label: A name to call this callback, must be unique (and hashable)
+            id: A name to call this callback, must be unique (and hashable)
                 or None, if non-unique a RuntimeError will be raised.
-                If None, a unique label will be automatically generated.
-                NOTE: Callbacks can be removed using their label.
+                If None, a unique id will be automatically generated.
+                NOTE: Callbacks can be removed using their id.
                       (see remove_callback)
             takes_target_args: If True, callback function will be passed the
                 arguments and keyword arguments that are supplied to the
@@ -315,37 +250,16 @@ class SupportsCallbacks(AbstractCallbackRegistry):
                 the exception has already been handled, this callback will
                 not be called.
         Returns:
-            label
-        '''
+            id
+        """
         return self._add_callback(
-            callback=callback, priority=priority, label=label, type='exception',
+            callback=callback, priority=priority, id=id,
             extra={'takes_args': takes_target_args,
                    'handles_exception': handles_exception})
 
-    def _call_pre_callbacks(self, *args, **kwargs):
-        for callback, extra in self._iter_callbacks('pre'):
-            takes_target_args = extra['takes_args']
-            if takes_target_args:
-                callback(*args, **kwargs)
-            else:
-                callback()
-
-    def _call_post_callbacks(self, target_result, *args, **kwargs):
-        for callback, extra in self._iter_callbacks('post'):
-            takes_target_args = extra['takes_args']
-            takes_target_result = extra['takes_result']
-            if takes_target_args and takes_target_result:
-                callback(target_result, *args, **kwargs)
-            elif takes_target_result:
-                callback(target_result)
-            elif takes_target_args:
-                callback(*args, **kwargs)
-            else:
-                callback()
-
-    def _call_exception_callbacks(self, exception, *args, **kwargs):
+    def emit(self, exception, *args, **kwargs):
         result = None
-        for callback, extra in self._iter_callbacks('exception'):
+        for callback, id, extra in self._iter_callbacks():
             takes_target_args = extra['takes_args']
             handles_exception = extra['handles_exception']
 
@@ -377,58 +291,311 @@ class SupportsCallbacks(AbstractCallbackRegistry):
         else:
             return result
 
-    def _update_docstring(self, target):
-            method_or_function = {True: 'method',
-                                  False: 'function'}
-            old_docstring = target.__doc__
-            if old_docstring is None:
-                old_docstring = '<No docstring was previously set>'
 
-            docstring = '''
-        %s%s
-    %s
-
-    This %s supports callbacks.
-      %s.add_pre_callback(callback)          returns: label
-      %s.add_post_callback(callback)         returns: label
-      %s.add_exception_callback(callback)    returns: label
-      %s.remove_callback(label)              removes a single callback
-      %s.remove_callbacks()                  removes all callbacks
-      %s.list_callbacks()                    prints callback information
-    ''' % (target.__name__,
-           inspect.formatargspec(*self._argspec),
-           old_docstring,
-           method_or_function[self._target_is_method],
-           target.__name__,
-           target.__name__,
-           target.__name__,
-           target.__name__,
-           target.__name__,
-           target.__name__)
-
-            self.__doc__ = docstring
-
-
-def supports_callbacks(target=None):
+class AbstractCallbackRegistry(object):
     """
-        This is a decorator.  Once a function/method is decorated, you can
-    register callbacks:
-        <target>.add_pre_callback(callback)        returns: label
-        <target>.add_post_callback(callback)       returns: label
-        <target>.add_exception_callback(callback)  returns: label
+    This decorator enables a function or a class/instance method to register
+    callbacks.
+
+    - Callbacks are organized by Event
+    - A CallbackRegistry stores one or more events as attributes
+    """
+
+    def __init__(self, target):
+        self.__name__ = target.__name__
+        self.target = target
+        if hasattr(target, '_argspec'):
+            self._argspec = target._argspec
+        else:
+            self._argspec = inspect.getargspec(target)
+
+        self._target_is_method = False
+        self._events = []
+        # this will hold the registries for instance method callbacks
+        self._instance_registries = WeakKeyDictionary()
+        self._initialize()
+        # must occur after initialize:
+        self._update_docstring(self.target)
+
+    def _add_event(self, name, type=Event):
+        """
+        Add an Event to this registry.  Should be called from _initialize on
+        sub-classes
+        """
+        event = type(name, self.__name__)
+        self._events.append(event)
+        return event
+
+    def _initialize(self):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        print('self %s %s' % (self, self.target))
+        return self.target(*args, **kwargs)
+
+    def __get__(self, obj, obj_type):
+        # method is being called on the class instead of an instance
+        if obj is None:
+            # when target was decorated, it had not been bound yet, but now it
+            # is, so update _target_is_method.
+            self._target_is_method = True
+            return self
+
+        if obj not in self._instance_registries:
+            callback_registry = self.__class__(self)
+            callback_registry._target_is_method=True
+            self._instance_registries[obj] = callback_registry
+        else:
+            callback_registry = self._instance_registries[obj]
+
+        return create_bound_method(callback_registry, obj)
+
+    @property
+    def _callbacks_info(self):
+        extra_ids = set()
+        for event in self._events:
+            for info in event.callbacks.values():
+                extra_ids.update(info['extra'].keys())
+        extra_ids = sorted(extra_ids)
+        format_extra = '  '.join(['{%s:<%d}' % (x, len(x))
+                                  for x in extra_ids])
+
+        format_string = ('{id:<38}  {priority:<9}  {order:<6}  {type:<15}  '
+                         '{extra}')
+        lines = []
+        lines.append(
+            format_string.format(id='Label', priority='Priority',
+                                 order='Order', type='Event',
+                                 extra=format_extra.format(
+                                     **{x : x.replace('_', ' ').capitalize()
+                                        for x in extra_ids})))
+
+        def format_val(v):
+            if v is True:
+                return 'true'
+            if v is False:
+                return 'false'
+            return v
+
+        for event in self._events:
+            for id, info in sorted(event.callbacks.items()):
+                order = event._priorities[info['priority']].index(id)
+                extra = info['extra']
+                lines.append(
+                    format_string.format(id=id, priority=info['priority'],
+                                         order=order, type=event.name,
+                                         extra=format_extra.format(
+                                             **{x : format_val(extra.get(x, 'N/A'))
+                                                for x in extra_ids})).rstrip())
+
+        return '\n'.join(lines)
+
+    def list_callbacks(self):
+        """
+        List all of the callbacks registered to this function or method.
+        """
+        print(self._callbacks_info)
+
+    def remove_callback(self, id):
+        for event in self._events:
+            try:
+                event.remove_callback(id)
+            except RuntimeError:
+                continue
+            else:
+                return
+        raise
+
+    def remove_callbacks(self):
+        """
+        Remove callbacks from all events
+        """
+        for event in self._events:
+            event.remove_callbacks()
+        # FIXME: should we also wipe _instance_registries?
+
+    @property
+    def num_callbacks(self):
+        """
+        Returns the number of callbacks that have been registered on this
+        function/method.  If called on an instance-method then it will also
+        add the number of class-level callbacks.
+
+        Returns:
+            num_callbacks
+            -or-
+            num_class_level_callbacks + num_instance_level_callbacks
+        """
+        num = sum(len(event.callbacks) for event in self._events)
+        if isinstance(self.target, self.__class__):
+            return self.target.num_callbacks + num
+        else:
+            return num
+
+    def _update_docstring(self, target):
+        old_docstring = target.__doc__
+        if old_docstring is None:
+            old_docstring = '<No docstring was previously set>'
+
+        lines = ["This %s supports callbacks:"]
+        for event in self._events:
+            lines.append('  {}.add_callback(callable) -> id'.format(event.name))
+            lines.append('  {}.remove_callback(id)'.format(event.name))
+        lines.extend(
+            [
+                '  remove_callbacks()',
+                '  list_callbacks()'
+            ]
+        )
+        # TODO: smarter entabbing
+        lines = ["    " + line for line in lines]
+        self.__doc__ = old_docstring + '\n'.join(lines)
+
+
+class SingleEvent(AbstractCallbackRegistry):
+    def _initialize(self):
+        self.event = self._add_event('event', Event)
+        self.add_callback = self.event.add_callback
+
+
+class AutoCallbacks(AbstractCallbackRegistry):
+    """
+
+    This is a decorator.  Once a function/method is decorated, callbacks can
+    be registered to be run before or after the target function (or after the
+    target function raises an exception).
+
+    to register callbacks:
+        <target>.on_call.add_callback(callback) -> id
+        <target>.on_return.add_callback(callback) -> id
+        <target>.on_exception.add_callback(callback) -> id
     where <target> is the function/method that was decorated.
 
     To remove a callback you use:
-        <target>.remove_callback(label)
+        <target>.remove_callback(id)
 
     To remove all callbacks use:
         <target>.remove_callbacks()
 
     To print a list of callbacks use:
         <target>.list_callbacks()
+
     """
-    if callable(target):
-        # this support bare @supports_callbacks syntax (no calling brackets)
-        return SupportsCallbacks(target)
-    else:
-        return SupportsCallbacks
+    def _initialize(self):
+        self.on_call = self._add_event('on_call', Event)
+        self.on_return = self._add_event('on_return', PostReturnEvent)
+        self.on_exception = self._add_event('on_exception', ExceptionEvent)
+
+    def __call__(self, *args, **kwargs):
+        print('self %s %s' % (self, self.target))
+        if self._target_is_method:
+            cb_args = args[1:]  # skip over 'self' arg
+        else:
+            cb_args = args
+
+        self.on_call.emit(*cb_args, **kwargs)
+        try:
+            target_result = self.target(*args, **kwargs)
+        except Exception as e:
+            target_result = self.on_exception.emit(e, *cb_args, **kwargs)
+        self.on_return.emit(target_result, *cb_args, **kwargs)
+        return target_result
+
+    # -- wrappers, for backward compatibility
+
+    def add_pre_callback(self, callback, priority=0, label=None,
+                         takes_target_args=False):
+        """
+        Registers the callback to be called before the target.
+
+        Inputs:
+            callback: The callback function that will be called before
+                the target function is run.
+            priority: Number. Higher priority callbacks are run first,
+                ties are broken by the order in which callbacks were added.
+            label: A name to call this callback, must be unique (and hashable)
+                or None, if non-unique a RuntimeError will be raised.
+                If None, a unique label will be automatically generated.
+                NOTE: Callbacks can be removed using their label.
+                      (see remove_callback)
+            takes_target_args: If True, callback function will be passed the
+                arguments and keyword arguments that are supplied to the
+                target function.
+        Returns:
+            label
+        """
+        return self.on_call.add_callback(
+            callback=callback, priority=priority, id=label,
+            takes_target_args=takes_target_args)
+
+    def add_post_callback(self, callback, priority=0, label=None,
+                          takes_target_args=False,
+                          takes_target_result=False):
+        """
+            Registers the callback to be called after the target is called.
+
+        Inputs:
+            callback: The callback function that will be called after
+                the target is called.
+            priority: Number. Higher priority callbacks are run first,
+                ties are broken by the order in which callbacks were added.
+            label: A name to call this callback, must be unique (and hashable)
+                or None, if non-unique a RuntimeError will be raised.
+                If None, a unique label will be automatically generated.
+                NOTE: Callbacks can be removed using their label.
+                      (see remove_callback)
+            takes_target_args: If True, callback function will be passed the
+                arguments and keyword arguments that are supplied to the
+                target function.
+            takes_target_result: If True, callback will be passed, as
+                its first argument, the value returned from calling the
+                target function.
+        Returns:
+            label
+        """
+        return self.on_return.add_callback(
+            callback=callback, priority=priority, id=label,
+            takes_target_args=takes_target_args,
+            takes_target_result=takes_target_result)
+
+    # alias
+    add_callback = add_post_callback
+
+    def add_exception_callback(self, callback, priority=0, label=None,
+                               takes_target_args=False,
+                               handles_exception=False):
+        """
+            Registers the callback to be called after the target raises an
+        exception.  Exception callbacks are called in priority order and can
+        handle the exception if they register with <handles_exception>.
+
+        Inputs:
+            callback: The callback function that will be called after
+                the target function raises an exception.
+            priority: Number. Higher priority callbacks are run first,
+                ties are broken by the order in which callbacks were added.
+            label: A name to call this callback, must be unique (and hashable)
+                or None, if non-unique a RuntimeError will be raised.
+                If None, a unique label will be automatically generated.
+                NOTE: Callbacks can be removed using their label.
+                      (see remove_callback)
+            takes_target_args: If True, callback function will be passed the
+                arguments and keyword arguments that are supplied to the
+                target function.
+            handles_exception: If True, callback will be passed (as
+                its first argument) the exception raised by the target function
+                or a higher priority exception_callback which raised an
+                exception.  If True, this function is responsible for
+                handling the exception or reraising it!  NOTE: If True and
+                the exception has already been handled, this callback will
+                not be called.
+        Returns:
+            label
+        """
+        return self.on_exception.add_callback(
+            callback=callback, priority=priority, id=label,
+            takes_target_args=takes_target_args,
+            handles_exception=handles_exception)
+
+
+supports_callbacks = AutoCallbacks

--- a/callbacks/callbacks.py
+++ b/callbacks/callbacks.py
@@ -1,10 +1,29 @@
-from types import MethodType
+from __future__ import absolute_import, print_function
+
+import types
 from collections import defaultdict
 from weakref import WeakKeyDictionary, proxy
 import uuid
 import inspect
+import sys
 
-class SupportsCallbacks(object):
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+
+class AbstractCallbackRegistry(object):
     '''
         This decorator enables a function or a class/instance method to register
     callbacks.  Callbacks can be registered to be run before or after the
@@ -22,7 +41,6 @@ class SupportsCallbacks(object):
             self._argspec = inspect.getargspec(target)
 
         self._target_is_method = target_is_method
-        self._update_docstring(target)
         self._initialize()
 
     @property
@@ -37,11 +55,143 @@ class SupportsCallbacks(object):
             -or-
             (num_class_level_callbacks, num_instance_level_callbacks)
         """
-        num = len(self.callbacks.keys())
-        if (isinstance(self.target, self.__class__)):
-            return (self.target.num_callbacks, num)
+        num = len(self.callbacks)
+        if isinstance(self.target, self.__class__):
+            return self.target.num_callbacks, num
         else:
             return num
+
+    def _initialize(self):
+        # this will hold the registries for instance method callbacks
+        self._callback_registries = WeakKeyDictionary()
+
+        # this holds the callback functions and how they should be called
+        self.callbacks = defaultdict(dict)
+        self._priorities = defaultdict(lambda: defaultdict(list))
+
+    def _iter_callbacks(self, type):
+        '''
+        Iterate over callbacks in order of priority.
+        '''
+        for priority in sorted(self._priorities[type].keys(), reverse=True):
+            for label in self._priorities[type][priority]:
+                info = self.callbacks[label]
+                yield (info['function'], info['extra'])
+
+    @property
+    def _callbacks_info(self):
+        extra_labels = set()
+        for info in self.callbacks.values():
+            extra_labels.update(info['extra'].keys())
+        extra_labels = sorted(extra_labels)
+        format_extra = '  '.join(['{%s:<%d}' % (x, len(x))
+                                  for x in extra_labels])
+        format_string = '{label:<38}  {priority:<9}  {order:<6}  {type:<10}  {extra}'
+        lines = []
+        lines.append(
+            format_string.format(label='Label', priority='Priority',
+                                 order='Order', type='Type',
+                                 extra=format_extra.format(
+                                     **{x : x.replace('_', ' ').capitalize()
+                                        for x in extra_labels})))
+
+        for label, info in sorted(self.callbacks.items()):
+            order = self._priorities[info['type']][info['priority']].index(label)
+            extra = info['extra']
+            lines.append(
+                format_string.format(label=label, priority=info['priority'],
+                                     order=order, type=info['type'],
+                                     extra=format_extra.format(
+                                         **{x : extra.get(x, 'N/A')
+                                            for x in extra_labels})).rstrip())
+
+        return '\n'.join(lines)
+
+    def list_callbacks(self):
+        '''
+            List all of the callbacks registered to this function or method.
+        '''
+        print(self._callbacks_info)
+
+    def _add_callback(self, callback, priority, label, type, extra):
+        try:
+            priority = float(priority)
+        except:
+            raise ValueError('Priority could not be cast into a float.')
+
+        if label is None:
+            label = uuid.uuid4()
+
+        if label in self.callbacks.keys():
+            raise RuntimeError('Callback with label="%s" already registered.'
+                               % label)
+
+        entry = {
+            'function': callback,
+            'priority': priority,
+            'type': type,
+            'extra': extra or {}
+        }
+        self.callbacks[label] = entry
+        self._priorities[type][priority].append(label)
+        return label
+
+    def remove_callback(self, label):
+        '''
+        Unregisters the callback from the target.
+
+        Inputs:
+            label: The name of the callback.  This was either supplied as a
+                keyword argument to add_callback or was automatically generated
+                and returned from add_callback. If label is not valid a
+                RuntimeError is raised.
+        Returns:
+            None
+        '''
+        if label not in self.callbacks:
+            raise RuntimeError(
+                'No callback with label "%s" attached to function "%s"' %
+                (label, self.target.__name__))
+
+        for priomap in self._priorities.values():
+            for priority in priomap.keys():
+                if label in priomap[priority]:
+                    priomap[priority].remove(label)
+
+        del self.callbacks[label]
+
+    def remove_callbacks(self, labels=None):
+        '''
+        Unregisters callback(s) from the target.
+
+        Inputs:
+            labels: A list of callback labels.  If empty, all callbacks will
+                be removed.
+        Returns:
+            None
+        '''
+        if labels is not None:
+            bad_labels = []
+            for label in labels:
+                try:
+                    self.remove_callback(label)
+                except RuntimeError:
+                    bad_labels.append(label)
+                    continue
+            if bad_labels:
+                raise RuntimeError(
+                    'No callbacks with labels %s attached to function %s' %
+                    (bad_labels, self.target.__name__))
+        else:
+            self._initialize()
+
+
+class SupportsCallbacks(AbstractCallbackRegistry):
+    def _initialize(self):
+        super(SupportsCallbacks, self)._initialize()
+        self._update_docstring(self.target)
+        # alias
+        self.add_callback = self.add_post_callback
 
     def __get__(self, obj, obj_type=None):
         """
@@ -57,87 +207,61 @@ class SupportsCallbacks(object):
             self._target_is_method = True
             return self
 
-        if (obj not in self._callback_registries):
-            callback_registry = SupportsCallbacks(self,
-                    target_is_method=True)
+        if obj not in self._callback_registries:
+            callback_registry = self.__class__(
+                self, target_is_method=True)
             self._callback_registries[obj] = proxy(callback_registry)
         else:
             callback_registry = self._callback_registries[obj]
 
-        return MethodType(callback_registry, obj, obj_type)
+        return create_bound_method(callback_registry, obj)
 
-    def _update_docstring(self, target):
-        method_or_function = {True:'method',
-                              False:'function'}
-        old_docstring = target.__doc__
-        if old_docstring is None:
-            old_docstring = '<No docstring was previously set>'
+    def __call__(self, *args, **kwargs):
+        print('self %s %s' % (self, self.target))
+        if self._target_is_method:
+            cb_args = args[1:]  # skip over 'self' arg
+        else:
+            cb_args = args
 
-        docstring = '''
-    %s%s
-%s
+        self._call_pre_callbacks(*cb_args, **kwargs)
+        try:
+            target_result = self.target(*args, **kwargs)
+        except Exception as e:
+            target_result = self._call_exception_callbacks(e, *cb_args, **kwargs)
+        self._call_post_callbacks(target_result, *cb_args, **kwargs)
+        return target_result
 
-This %s supports callbacks.
-  %s.add_pre_callback(callback)          returns: label
-  %s.add_post_callback(callback)         returns: label
-  %s.add_exception_callback(callback)    returns: label
-  %s.remove_callback(label)              removes a single callback
-  %s.remove_callbacks()                  removes all callbacks
-  %s.list_callbacks()                    prints callback information
-''' % (target.__name__,
-               inspect.formatargspec(*self._argspec),
-               old_docstring,
-               method_or_function[self._target_is_method],
-               target.__name__,
-               target.__name__,
-               target.__name__,
-               target.__name__,
-               target.__name__,
-               target.__name__)
-
-        self.__doc__ = docstring
-
-    def _initialize(self):
-        # this will hold the registries for instance method callbacks
-        self._callback_registries = WeakKeyDictionary()
-
-        # these hold the order in which callbacks were added
-        self._pre_callbacks = defaultdict(list)
-        self._post_callbacks = defaultdict(list)
-        self._exception_callbacks = defaultdict(list)
-        # this holds the callback functions and how they should be called
-        self.callbacks = defaultdict(dict)
-
-        # alias
-        self.add_callback = self.add_post_callback
-
-    @property
-    def _callbacks_info(self):
-        format_string = '%38s  %9s  %6s  %10s  %11s  %14s'
-        lines = []
-        lines.append(format_string %
-                ('Label', 'priority', 'order', 'type', 'takes args', 'takes result'))
-
-        for label, info in sorted(self.callbacks.items()):
-            order = getattr(self, '_%s_callbacks' % info['type'])[info['priority']].index(label)
-            lines.append(format_string % (label, info['priority'], order,
-                    info['type'], info['takes_target_args'], info.get('takes_target_result', 'N/A')))
-
-        return '\n'.join(lines)
-
-    def list_callbacks(self):
+    def add_pre_callback(self, callback, priority=0, label=None,
+                         takes_target_args=False):
         '''
-            List all of the callbacks registered to this function or method.
-        '''
-        print self._callbacks_info
+        Registers the callback to be called before the target.
 
-    def add_post_callback(self, callback,
-            priority=0,
-            label=None,
-            takes_target_args=False,
-            takes_target_result=False):
+        Inputs:
+            callback: The callback function that will be called before
+                the target function is run.
+            priority: Number. Higher priority callbacks are run first,
+                ties are broken by the order in which callbacks were added.
+            label: A name to call this callback, must be unique (and hashable)
+                or None, if non-unique a RuntimeError will be raised.
+                If None, a unique label will be automatically generated.
+                NOTE: Callbacks can be removed using their label.
+                      (see remove_callback)
+            takes_target_args: If True, callback function will be passed the
+                arguments and keyword arguments that are supplied to the
+                target function.
+        Returns:
+            label
+        '''
+        return self._add_callback(
+            callback=callback, priority=priority, label=label, type='pre',
+            extra={'takes_args': takes_target_args})
+
+    def add_post_callback(self, callback, priority=0, label=None,
+                          takes_target_args=False,
+                          takes_target_result=False):
         '''
             Registers the callback to be called after the target is called.
+
         Inputs:
             callback: The callback function that will be called after
                 the target is called.
@@ -157,22 +281,19 @@ This %s supports callbacks.
         Returns:
             label
         '''
-        priority, label = self._add_callback(callback=callback,
-                priority=priority, label=label,
-                takes_target_args=takes_target_args, type='post')
-        self._post_callbacks[priority].append(label)
-        self.callbacks[label]['takes_target_result'] = takes_target_result
-        return label
+        return self._add_callback(
+            callback=callback, priority=priority, label=label, type='post',
+            extra={'takes_args': takes_target_args,
+                   'takes_result': takes_target_result})
 
-    def add_exception_callback(self, callback,
-            priority=0,
-            label=None,
-            takes_target_args=False,
-            handles_exception=False):
+    def add_exception_callback(self, callback, priority=0, label=None,
+                               takes_target_args=False,
+                               handles_exception=False):
         '''
             Registers the callback to be called after the target raises an
         exception.  Exception callbacks are called in priority order and can
         handle the exception if they register with <handles_exception>.
+
         Inputs:
             callback: The callback function that will be called after
                 the target function raises an exception.
@@ -196,182 +317,97 @@ This %s supports callbacks.
         Returns:
             label
         '''
-        priority, label = self._add_callback(callback=callback,
-                priority=priority, label=label,
-                takes_target_args=takes_target_args, type='exception')
-        self._exception_callbacks[priority].append(label)
-        self.callbacks[label]['handles_exception'] = handles_exception
-        return label
-
-    def add_pre_callback(self, callback,
-            priority=0,
-            label=None,
-            takes_target_args=False):
-        '''
-        Registers the callback to be called before the target.
-        Inputs:
-            callback: The callback function that will be called before
-                the target function is run.
-            priority: Number. Higher priority callbacks are run first,
-                ties are broken by the order in which callbacks were added.
-            label: A name to call this callback, must be unique (and hashable)
-                or None, if non-unique a RuntimeError will be raised.
-                If None, a unique label will be automatically generated.
-                NOTE: Callbacks can be removed using their label.
-                      (see remove_callback)
-            takes_target_args: If True, callback function will be passed the
-                arguments and keyword arguments that are supplied to the
-                target function.
-        Returns:
-            label
-        '''
-        priority, label = self._add_callback(callback=callback,
-                priority=priority, label=label,
-                takes_target_args=takes_target_args, type='pre')
-        self._pre_callbacks[priority].append(label)
-        return label
-
-    def _add_callback(self, callback, priority, label, takes_target_args, type):
-        try:
-            priority = float(priority)
-        except:
-            raise ValueError('Priority could not be cast into a float.')
-
-        if label is None:
-            label = uuid.uuid4()
-
-        if label in self.callbacks.keys():
-            raise RuntimeError('Callback with label="%s" already registered.'
-                    % label)
-
-        self.callbacks[label]['function'] = callback
-        self.callbacks[label]['priority'] = priority
-        self.callbacks[label]['takes_target_args'] = takes_target_args
-        self.callbacks[label]['type'] = type
-
-        return priority, label
-
-    def remove_callback(self, label):
-        '''
-        Unregisters the callback from the target.
-        Inputs:
-            label: The name of the callback.  This was either supplied as a
-                keyword argument to add_callback or was automatically generated
-                and returned from add_callback. If label is not valid a
-                RuntimeError is raised.
-        Returns:
-            None
-        '''
-        if label not in self.callbacks.keys():
-            raise RuntimeError(
-                    'No callback with label "%s" attached to function "%s"' %
-                    (label, self.target.__name__))
-
-        for index in [self._pre_callbacks, self._post_callbacks,
-                self._exception_callbacks]:
-            for priority in index.keys():
-                if label in index[priority]:
-                    index[priority].remove(label)
-
-        del self.callbacks[label]
-
-    def remove_callbacks(self, labels=None):
-        '''
-        Unregisters callback(s) from the target.
-        Inputs:
-            labels: A list of callback labels.  If empty, all callbacks will
-                be removed.
-        Returns:
-            None
-        '''
-        if labels is not None:
-            bad_labels = []
-            for label in labels:
-                try:
-                    self.remove_callback(label)
-                except RuntimeError:
-                    bad_labels.append(label)
-                    continue
-            if bad_labels:
-                raise RuntimeError(
-                    'No callbacks with labels %s attached to function %s' %
-                    (bad_labels, self.target.__name__))
-        else:
-            self._initialize()
-
-    def __call__(self, *args, **kwargs):
-        print 'self', self, self.target
-        if self._target_is_method:
-            cb_args = args[1:] # skip over 'self' arg
-        else:
-            cb_args = args
-
-        self._call_pre_callbacks(*cb_args, **kwargs)
-        try:
-            target_result = self.target(*args, **kwargs)
-        except Exception as e:
-            target_result = self._call_exception_callbacks(e, *cb_args, **kwargs)
-        self._call_post_callbacks(target_result, *cb_args, **kwargs)
-        return target_result
+        return self._add_callback(
+            callback=callback, priority=priority, label=label, type='exception',
+            extra={'takes_args': takes_target_args,
+                   'handles_exception': handles_exception})
 
     def _call_pre_callbacks(self, *args, **kwargs):
-        for priority in sorted(self._pre_callbacks.keys(), reverse=True):
-            for label in self._pre_callbacks[priority]:
-                callback = self.callbacks[label]['function']
-                takes_target_args = self.callbacks[label]['takes_target_args']
-                if takes_target_args:
-                    callback(*args, **kwargs)
-                else:
-                    callback()
+        for callback, extra in self._iter_callbacks('pre'):
+            takes_target_args = extra['takes_args']
+            if takes_target_args:
+                callback(*args, **kwargs)
+            else:
+                callback()
+
+    def _call_post_callbacks(self, target_result, *args, **kwargs):
+        for callback, extra in self._iter_callbacks('post'):
+            takes_target_args = extra['takes_args']
+            takes_target_result = extra['takes_result']
+            if takes_target_args and takes_target_result:
+                callback(target_result, *args, **kwargs)
+            elif takes_target_result:
+                callback(target_result)
+            elif takes_target_args:
+                callback(*args, **kwargs)
+            else:
+                callback()
 
     def _call_exception_callbacks(self, exception, *args, **kwargs):
         result = None
-        for priority in sorted(self._exception_callbacks.keys(), reverse=True):
-            for label in self._exception_callbacks[priority]:
-                callback = self.callbacks[label]['function']
-                takes_target_args = self.callbacks[label]['takes_target_args']
-                handles_exception = self.callbacks[label]['handles_exception']
+        for callback, extra in self._iter_callbacks('exception'):
+            takes_target_args = extra['takes_args']
+            handles_exception = extra['handles_exception']
 
-                if handles_exception and exception is None:
-                    # exception has already been handled, only call callbacks
-                    # that don't handle exceptions
+            if handles_exception and exception is None:
+                # exception has already been handled, only call callbacks
+                # that don't handle exceptions
+                continue
+
+            if takes_target_args and handles_exception:
+                try:
+                    result = callback(exception, *args, **kwargs)
+                    exception = None
+                except Exception as exc:
+                    exception = exc
                     continue
-
-                if takes_target_args and handles_exception:
-                    try:
-                        result = callback(exception, *args, **kwargs)
-                        exception = None
-                    except Exception as exception:
-                        continue
-                elif handles_exception:
-                    try:
-                        result = callback(exception)
-                        exception = None
-                    except Exception as exception:
-                        continue
-                elif takes_target_args:
-                    callback(*args, **kwargs)
-                else:
-                    callback()
+            elif handles_exception:
+                try:
+                    result = callback(exception)
+                    exception = None
+                except Exception as exc:
+                    exception = exc
+                    continue
+            elif takes_target_args:
+                callback(*args, **kwargs)
+            else:
+                callback()
         if exception is not None:
             raise exception
         else:
             return result
 
-    def _call_post_callbacks(self, target_result, *args, **kwargs):
-        for priority in sorted(self._post_callbacks.keys(), reverse=True):
-            for label in self._post_callbacks[priority]:
-                callback = self.callbacks[label]['function']
-                takes_target_args = self.callbacks[label]['takes_target_args']
-                takes_target_result = self.callbacks[label]['takes_target_result']
-                if takes_target_args and takes_target_result:
-                    callback(target_result, *args, **kwargs)
-                elif takes_target_result:
-                    callback(target_result)
-                elif takes_target_args:
-                    callback(*args, **kwargs)
-                else:
-                    callback()
+    def _update_docstring(self, target):
+            method_or_function = {True: 'method',
+                                  False: 'function'}
+            old_docstring = target.__doc__
+            if old_docstring is None:
+                old_docstring = '<No docstring was previously set>'
+
+            docstring = '''
+        %s%s
+    %s
+
+    This %s supports callbacks.
+      %s.add_pre_callback(callback)          returns: label
+      %s.add_post_callback(callback)         returns: label
+      %s.add_exception_callback(callback)    returns: label
+      %s.remove_callback(label)              removes a single callback
+      %s.remove_callbacks()                  removes all callbacks
+      %s.list_callbacks()                    prints callback information
+    ''' % (target.__name__,
+           inspect.formatargspec(*self._argspec),
+           old_docstring,
+           method_or_function[self._target_is_method],
+           target.__name__,
+           target.__name__,
+           target.__name__,
+           target.__name__,
+           target.__name__,
+           target.__name__)
+
+            self.__doc__ = docstring
+
 
 def supports_callbacks(target=None):
     """

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import unittest
 import uuid
 
@@ -65,12 +66,13 @@ class TestCallbackDecorator(unittest.TestCase):
         foo.add_post_callback(callback, label='c', priority=1.1,
                 takes_target_result=True)
         foo.add_exception_callback(callback, label='d')
-        expected_string =\
-'''                                 Label   priority   order        type   takes args    takes result
-                                     a        0.0       0         pre        False             N/A
-                                     b        0.0       1         pre         True             N/A
-                                     c        1.1       0        post        False            True
-                                     d        0.0       0   exception        False             N/A'''
+        expected_string = '''\
+Label                                   Priority   Order   Type        Handles exception  Takes args  Takes result
+a                                       0.0        0       pre         N/A                0           N/A
+b                                       0.0        1       pre         N/A                1           N/A
+c                                       1.1        0       post        N/A                0           1
+d                                       0.0        0       exception   0                  0           N/A'''
+        print(foo._callbacks_info)
         self.assertEquals(expected_string, foo._callbacks_info)
 
     def test_with_takes_target_args(self):

--- a/tests/test_class_level_callbacks.py
+++ b/tests/test_class_level_callbacks.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import unittest
 
 from callbacks import supports_callbacks

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import unittest
 
 from callbacks import supports_callbacks

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -50,14 +50,14 @@ class TestExceptions(unittest.TestCase):
         foo.remove_callbacks()
 
     def test_c1(self):
-        foo.add_exception_callback(c1)
+        foo.on_exception.add_callback(c1)
 
         self.assertRaises(foo_error, foo, 1, baz=2)
 
         self.assertEqual(len(called_with), 0)
 
     def test_c2(self):
-        foo.add_exception_callback(c2, handles_exception=True)
+        foo.on_exception.add_callback(c2, handles_exception=True)
 
         self.assertRaises(foo_error, foo, 1, baz=2)
 
@@ -65,7 +65,7 @@ class TestExceptions(unittest.TestCase):
         self.assertTrue(isinstance(called_with[0][0], foo_error))
 
     def test_c3(self):
-        foo.add_exception_callback(c3, takes_target_args=True)
+        foo.on_exception.add_callback(c3, takes_target_args=True)
 
         self.assertRaises(foo_error, foo, 1, baz=2)
 
@@ -74,8 +74,8 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(called_with[0][1], {'baz':2})
 
     def test_c2_and_3(self):
-        foo.add_exception_callback(c2, handles_exception=True)
-        foo.add_exception_callback(c3, takes_target_args=True)
+        foo.on_exception.add_callback(c2, handles_exception=True)
+        foo.on_exception.add_callback(c3, takes_target_args=True)
 
         self.assertRaises(foo_error, foo, 1, baz=2)
 
@@ -85,7 +85,7 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(called_with[1][1], {'baz':2})
 
     def test_c4(self):
-        foo.add_exception_callback(c4, handles_exception=True,
+        foo.on_exception.add_callback(c4, handles_exception=True,
                 takes_target_args=True)
 
         result = foo(1, baz=2)
@@ -98,7 +98,7 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(expected_called_with, called_with)
 
     def test_c4_without_takes_args(self):
-        foo.add_exception_callback(c4, handles_exception=True)
+        foo.on_exception.add_callback(c4, handles_exception=True)
 
         result = foo(1, baz=2)
 
@@ -107,7 +107,7 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(expected_called_with, called_with)
 
     def test_c5(self):
-        foo.add_exception_callback(c5, handles_exception=True)
+        foo.on_exception.add_callback(c5, handles_exception=True)
 
         self.assertRaises(c5_error, foo, 1, baz=2)
 
@@ -115,7 +115,7 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(expected_called_with, called_with)
 
     def test_c5_takes_target_args(self):
-        foo.add_exception_callback(c5, takes_target_args=True, handles_exception=True)
+        foo.on_exception.add_callback(c5, takes_target_args=True, handles_exception=True)
 
         self.assertRaises(c5_error, foo, 1, baz=2)
 
@@ -124,9 +124,9 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(expected_called_with, called_with)
 
     def test_c3_and_c4_and_c5(self):
-        foo.add_exception_callback(c3, priority=0.1, takes_target_args=True)
-        foo.add_exception_callback(c5, priority=0.2, handles_exception=True)
-        foo.add_exception_callback(c4, priority=0.3, takes_target_args=True,
+        foo.on_exception.add_callback(c3, priority=0.1, takes_target_args=True)
+        foo.on_exception.add_callback(c5, priority=0.2, handles_exception=True)
+        foo.on_exception.add_callback(c4, priority=0.3, takes_target_args=True,
                 handles_exception=True)
 
         result = foo(1, baz=2)
@@ -141,9 +141,9 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(expected_called_with, called_with)
 
     def test_pre_post1(self):
-        foo.add_pre_callback(c3, takes_target_args=True)
+        foo.on_call.add_callback(c3, takes_target_args=True)
         foo.add_post_callback(c3, takes_target_args=True)
-        foo.add_exception_callback(c4, takes_target_args=True,
+        foo.on_exception.add_callback(c4, takes_target_args=True,
                 handles_exception=True)
 
         result = foo(1, baz=2)
@@ -159,9 +159,9 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(expected_called_with, called_with)
 
     def test_pre_post2(self):
-        foo.add_pre_callback(c3, takes_target_args=True)
+        foo.on_call.add_callback(c3, takes_target_args=True)
         foo.add_post_callback(c3, takes_target_args=True)
-        foo.add_exception_callback(c5, handles_exception=True)
+        foo.on_exception.add_callback(c5, handles_exception=True)
 
         self.assertRaises(c5_error, foo, 1, baz=2)
 

--- a/tests/test_method_callbacks.py
+++ b/tests/test_method_callbacks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from collections import defaultdict
 import unittest
 from mock import Mock
@@ -6,8 +8,8 @@ from callbacks import supports_callbacks
 
 callback_called_with = []
 def example_callback(*args, **kwargs):
-    print "CALLBACK called with args=%s kwargs=%s" %\
-                (str(args), str(kwargs))
+    print("CALLBACK called with args=%s kwargs=%s" %\
+                (str(args), str(kwargs)))
     callback_called_with.append((args, kwargs))
 
 class ExampleClass(object):
@@ -16,8 +18,8 @@ class ExampleClass(object):
 
     @supports_callbacks
     def example_method(self, *args, **kwargs):
-        print "METHOD called with args=%s kwargs=%s" %\
-                (str(args), str(kwargs))
+        print("METHOD called with args=%s kwargs=%s" %\
+                (str(args), str(kwargs)))
         self.method_called_with.append((args, kwargs))
         return
 

--- a/tests/test_method_callbacks.py
+++ b/tests/test_method_callbacks.py
@@ -38,7 +38,7 @@ class TestOnMethod(unittest.TestCase):
         self.assertEquals(e.method_called_with[0],
                 ((10, 20), {'key':'value'}))
 
-        e.example_method.add_callback(example_callback)
+        e.example_method.on_return.add_callback(example_callback)
 
         e.example_method(11, 21, key='another_value')
         self.assertEquals(len(callback_called_with), 1)
@@ -57,7 +57,7 @@ class TestOnMethod(unittest.TestCase):
         self.assertEquals(e.method_called_with[0],
                 ((10, 20), {'key':'value'}))
 
-        e.example_method.add_callback(example_callback,
+        e.example_method.on_return.add_callback(example_callback,
                 takes_target_args=True)
 
         e.example_method(11, 21, key='another_value')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27
+envlist = py27,py35
 
 [testenv]
 commands =


### PR DESCRIPTION
This is a pretty big refactor, and there's a chance you won't be interested in merging it, but I thought I'd give it a try.  I've reorganized the internals into smaller classes, so that custom recipes can be created from them.  My use case is that I want something very like what `callbacks` provides, but I need my functions to be in control of when the event fires (i.e. it is neither before or after the target function, but somewhere in the middle).

- callbacks are organized by event: An `Event` class is used to register callbacks.  it knows nothing about the target.  
- an event is triggered by calling `Event.emit()`, and may be sub-classed to add special behavior
- a `CallbackRegistry` stores the target and one or more events as attributes.  Callbacks are registered like `myfunction.event_name.add_callback`
- The existing automatic functionality is implemented using these various parts on `AutoCallbacks`.  The `add_*_callback` methods are available on this class, but the new style for adding callbacks is via the events:  e.g. `myfunction.on_call.add_callback`, `myfunction.on_return.add_callback`, and `myfunction.on_exception.add_callback`
- ids are now generated based on the callback function rather than uuids, so that callbacks can be removed without storing the returned id
- added python3 support

This is not done yet.  I still need to update docs, examples, and tests for the manual event emission, but I wanted to see what you thought first.  I've made a few breaking changes, but I can remove a most of them with a little more work.
